### PR TITLE
Add Travis verification recipe

### DIFF
--- a/recipes/travis.rb
+++ b/recipes/travis.rb
@@ -1,0 +1,26 @@
+require 'travis/pro'
+
+Capistrano::Configuration.instance(true).load do
+
+    namespace :ci do
+      desc "verification of branch build status on Travis CI"
+      task :verify do
+        begin
+          # strip git@github.com: and .git portion
+          travis_repo = repository[15..-5]
+
+          Travis::Pro.access_token = travis_key
+          repo = Travis::Pro::Repository.find(travis_repo)
+          branch_state = repo.branch(branch).state
+     
+          unless branch_state == "passed"
+            Capistrano::CLI.ui.say "Your '#{branch}' branch has '#{branch_state}' state on CI."
+            Capistrano::CLI.ui.ask("Continue anyway? (y/N)") == 'y' or abort
+          end
+        rescue => e
+          Capistrano::CLI.ui.say e.message
+        end
+      end
+    end
+
+end

--- a/recipiez.gemspec
+++ b/recipiez.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
   s.add_dependency('tinder')
+  s.add_dependency('travis')
     
   s.required_rubygems_version = ">= 1.3.1"
   s.require_path = 'lib'


### PR DESCRIPTION
This should allow adding the following lines to any repository and it will ask before deploying a non-passed branch:

```
set :travis_key, "pro_key_from_travis"
before 'deploy', 'ci:verify'
```

The pro key can be obtained by running `gem install travis && travis login --pro && travis token --pro`